### PR TITLE
Fix Google Drive permissions and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ project is in developpement.
 On first launch, the application will ask you for the authorization to access
 your files on Google Drive.  It only asks for permission to create new files or
  access files it has created or that you manually open with this application.
+It also requires permission to access file/directory metadata, in order
+to display the list of files/directories in the tree view.
 
 The request pop-up looks like the following:
 
@@ -53,5 +55,6 @@ at a later point.
 ![](img/popup.png)
 
 Once you click `Accept` you should be able to start creating new notebooks on
-Google Drive, and open existing ones created by this application.
+Google Drive, and open existing ones created by this application, and
+view files/directories in the tree view.
 

--- a/jupyterdrive/gdrive/gapi_utils.js
+++ b/jupyterdrive/gdrive/gapi_utils.js
@@ -7,6 +7,20 @@ define(function(require) {
     var $ = require('jquery');
     var dialog = require('base/js/dialog');
     var utils = require('base/js/utils');
+
+    /**
+     * OAuth scope for accessing specific files that have been opened/created
+     * by this app.
+     * @type {string}
+     */
+    var FILES_OAUTH_SCOPE = 'https://www.googleapis.com/auth/drive.file';
+
+    /**
+     * OAuth scope for accessing file metadata (for tree view)
+     * @type {string}
+     */
+    var METADATA_OAUTH_SCOPE = 'https://www.googleapis.com/auth/drive.readonly.metadata';
+
     /**
      * Helper functions
      */
@@ -135,7 +149,7 @@ define(function(require) {
             return new Promise(function(resolve, reject) {
                 gapi.auth.authorize({
                     'client_id': '911569945122-tlvi6ucbj137ifhitpqpdikf3qo1mh9d.apps.googleusercontent.com',
-                    'scope': ['https://www.googleapis.com/auth/drive'],
+                    'scope': [FILES_OAUTH_SCOPE, METADATA_OAUTH_SCOPE],
                     'immediate': !opt_withPopup
                 }, function(result) {
                     resolve(wrap_result(result));


### PR DESCRIPTION
Fixes Google Drive permissions so only access to files that were created/opened\* by the app can be accessed, in addition to readonly access to metadata.

Also updates the README to reflect new permissions, and fixes some spelling mistakes in the README.

*In this context "opened" has a special meaning, which is to open in the Google Drive website, or using their FilePicker GUI.  The important point is a file cannot be opened without explicit user knowledge/consent, so our app can't access any random file in Drive without the user knowing.  This should be explained in the README at some point.
