### PR TITLE
fix setup to framework::IPython

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     # https://packaging.python.org/en/latest/development.html#single-sourcing-the-version
     version='0.0.1a1',
 
-    description='Interation of IPython/Jupyter with google drive',
+    description='Integration of IPython/Jupyter with Google drive',
     long_description='',
 
     # The project's main homepage.


### PR DESCRIPTION
and it is now uploaded to PyPi : https://pypi.python.org/pypi/jupyterdrive so installable with pip as an early alpha. 

Do you guys have pypi username so hat I can add you as owner/maintainers / 
