### PR TITLE
Fix writing JSON file on Python 3

### DIFF
--- a/jupyterdrive/__init__.py
+++ b/jupyterdrive/__init__.py
@@ -2,6 +2,7 @@
 import IPython
 import IPython.html.nbextensions as nbe
 from IPython.utils.path import locate_profile
+from IPython.utils.py3compat import cast_unicode_py2
 
 
 import sys
@@ -41,8 +42,8 @@ def activate(profile):
     print(config)
     config['nbformat'] = 1
 
-    with io.open(os.path.join(pdir,'ipython_notebook_config.json'),'wb') as f:
-        json.dump(config,f, indent=2)
+    with io.open(os.path.join(pdir,'ipython_notebook_config.json'),'w', encoding='utf-8') as f:
+        f.write(cast_unicode_py2(json.dumps(config, indent=2)))
 
 def deactivate(profile):
     """should be a matter of just unsetting the above keys


### PR DESCRIPTION
Addresses gh-27; ping @rgbkrk 

This is admittedly inelegant, but since the json module on Python 2 can serialise to either bytes or unicode depending on the input, it seems like the most robust way to write json to a file.
