### PR TITLE
Update file format to follow v4 spec

### DIFF
--- a/jupyterdrive/gdrive/drive-contents.js
+++ b/jupyterdrive/gdrive/drive-contents.js
@@ -60,9 +60,11 @@ define(function(require) {
             var metadata = values[0];
             var contents = values[1];
             var model = notebook_model.notebook_from_file_contents(contents);
+            var path_components = drive_utils.split_path(path);
+            var name = path_components[path_components.length - 1];
             return {
                 content: model,
-                name: model.metadata.name,
+                name: name,
                 path:path,
                 writable: metadata['editable']
             };
@@ -84,7 +86,7 @@ define(function(require) {
 	    var folder_id = values[0];
 	    var filename = values[1];
 	    var contents = notebook_model.file_contents_from_notebook(
-		notebook_model.new_notebook(filename));
+		notebook_model.new_notebook());
             var metadata = {
                 'parents' : [{'id' : folder_id}],
                 'title' : filename,

--- a/jupyterdrive/gdrive/notebook_model.js
+++ b/jupyterdrive/gdrive/notebook_model.js
@@ -87,7 +87,7 @@ define(function(require) {
      * @param {string} name Notebook name
      * @return {Object} JSON representation of a new notebook.
      */
-    var new_notebook = function(name) {
+    var new_notebook = function() {
         return {
             'cells' : [{
                 'cell_type': 'code',
@@ -96,9 +96,7 @@ define(function(require) {
                 'language': 'python',
                 'metadata': {}
             }],
-            'metadata': {
-                'name': name,
-            },
+	    'metadata': {},
             'nbformat': 4,
             'nbformat_minor': 0
         };


### PR DESCRIPTION
Before, filename was being stored under notebook metadata, which is not the case in the v4 file format.  Now the filename is always the name of the actual file.
