### PR TITLE
Better conformance with IPEP 27

### DIFF
--- a/jupyterdrive/gdrive/drive-contents.js
+++ b/jupyterdrive/gdrive/drive-contents.js
@@ -354,9 +354,7 @@ define(function(require) {
             // (or from the start if no page token is specified), and
             // combines these with the items given.
             var get_items = function(items, page_token) {
-                var query = ('(fileExtension = \'ipynb\' or'
-                             + ' mimeType = \'' + drive_utils.FOLDER_MIME_TYPE + '\')'
-                             + ' and \'' + folder_id + '\' in parents'
+                var query = ('\'' + folder_id + '\' in parents'
                              + ' and trashed = false');
                 var params = {
                     'maxResults' : 1000,


### PR DESCRIPTION
Modifies return values so they return the JSON objects described in IPEP 27.  In particular, the 'name' and 'path' fields are made consistent with IPEP 27 when before 'path' was not always correct and both fields were sometimes missing.
