### PR TITLE
fix clisentside contents

### DIFF
--- a/jupyterdrive/clientsidenbmanager.py
+++ b/jupyterdrive/clientsidenbmanager.py
@@ -21,3 +21,7 @@ class ClientSideContentsManager(ContentsManager):
 
     def file_exists(self, name, path=''):
         return True
+
+    def get(self, path, **kwargs):
+        ## if ends with ipynb
+        return {'type':'notebook'}


### PR DESCRIPTION
Recent change server side make server raise. 

This fixes that. 

I'm still stuck with drive only acceptign to acces new files I create but not old ones. I've narrowed it down to at gapi.download that return a not found, while metadata_prm, does say it exist and return metadata 