### PR TITLE
Use Google FilePicker to open files

### DIFF
--- a/jupyterdrive/gdrive/drive-contents.js
+++ b/jupyterdrive/gdrive/drive-contents.js
@@ -10,6 +10,7 @@ define(function(require) {
     var gapi_utils = require('./gapi_utils');
     var drive_utils = require('./drive_utils');
     var notebook_model = require('./notebook_model');
+    var picker_utils = require('./picker_utils');
 
     var Contents = function(options) {
         // Constructor
@@ -107,22 +108,16 @@ define(function(require) {
             $.proxy(drive_utils.get_resource_for_path, this, path, drive_utils.FileType.FILE));
         var contents_prm = metadata_prm.then(function(resource) {
             that.observe_file_resource(resource);
-            return gapi_utils
-                .download(resource['downloadUrl'])
-                .catch(function(data){
-                    var reason ='Unknown Error.';
-                    if( data.xhr.status === 404){
-                        reason = 'We cannot access requested resource. \n'+
-                                 'This can happen if the resource was not created with jupyter drive.\n'+
-                                 'Please re-upload the resource by dragging a copy of the file onto the Jupyter file manager';
-                    } else if (data.xhr.status === 401){
-                        reason = "You don't have permission to access this resource";
-                    }
-                    var error = new Error(reason);
-                    error.name = 'DriveDownloadError';
-                    return Promise.reject(error);
-                });
-        });
+            return gapi_utils.download(resource['downloadUrl'])
+            .catch(function(error){
+                if (error.xhr.status != 404) {
+                    return error;  // Should this be Promise.reject(error)???
+                }
+                return picker_utils.pick_file(resource.parents[0]['id'], resource['title'])
+                .then(function() { return gapi_utils.download(resource['downloadUrl']); });
+            });
+        })
+
         return Promise.all([metadata_prm, contents_prm]).then(function(values) {
             var metadata = values[0];
             var contents = values[1];

--- a/jupyterdrive/gdrive/gapi_utils.js
+++ b/jupyterdrive/gdrive/gapi_utils.js
@@ -9,6 +9,18 @@ define(function(require) {
     var utils = require('base/js/utils');
 
     /**
+     * Google API Client ID
+     * @type {string}
+     */
+    var CLIENT_ID = '763546234320-uvcktfp0udklafjqv00qjgivpjh0t33p.apps.googleusercontent.com';
+
+    /**
+     * Google API App ID
+     * @type {string}
+     */
+    var APP_ID = '763546234320';
+
+    /**
      * OAuth scope for accessing specific files that have been opened/created
      * by this app.
      * @type {string}
@@ -143,7 +155,7 @@ define(function(require) {
      */
     var load_gapi_2 = function(d) {
         return new Promise(function(resolve, reject) {
-            gapi.load('auth:client,drive-realtime,drive-share', function() {
+            gapi.load('auth:client,drive-realtime,drive-share,picker', function() {
                 gapi.client.load('drive', 'v2', resolve);
             });
         });
@@ -158,7 +170,7 @@ define(function(require) {
         var authorize_internal = function() {
             return new Promise(function(resolve, reject) {
                 gapi.auth.authorize({
-                    'client_id': '763546234320-uvcktfp0udklafjqv00qjgivpjh0t33p.apps.googleusercontent.com',
+                    'client_id': CLIENT_ID,
                     'scope': [FILES_OAUTH_SCOPE, METADATA_OAUTH_SCOPE],
                     'immediate': !opt_withPopup
                 }, function(result) {
@@ -207,6 +219,7 @@ define(function(require) {
     var gapi_ready = load_gapi_1().then(load_gapi_2).then(authorize);
 
     var drive_utils = {
+        APP_ID : APP_ID,
         download : download,
         execute : execute,
         gapi_ready : gapi_ready

--- a/jupyterdrive/gdrive/picker_utils.js
+++ b/jupyterdrive/gdrive/picker_utils.js
@@ -1,0 +1,52 @@
+// Copyright (c) IPython Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+define(function(require) {
+    var gapi_utils = require('./gapi_utils');
+
+    /**
+     * Gets the user to pick a file in the file picker.  This indicates to
+     * Google Drive that the user has consented to open that file with this
+     * app, and therefore the app is able to access the file under drive.file
+     * scope.
+     * @param {String} parent_id The folder id of the parent folder
+     * @param {String} filename The name (not id) of the file
+     * @param {Promise} a Promise resolved when user selects file, or rejected if
+     *     they cancel.
+     */
+    var pick_file = function(parent_id, filename) {
+        return new Promise(function(resolve, reject) {
+            var callback = function(response) {
+                if (response['action'] == google.picker.Action.CANCEL) {
+                    var reason = 'This file cannot be opened unless you select it in the Google Drive file picker.';
+                    var error = new Error(reason);
+                    error.name = 'DriveDownloadError';
+                    reject(error);
+                } else if (response['action'] == google.picker.Action.PICKED) {
+                    resolve();
+                }
+            };
+            var builder = new google.picker.PickerBuilder();
+
+            var search_view = new google.picker.DocsView(google.picker.ViewId.DOCS)
+                .setMode(google.picker.DocsViewMode.LIST)
+                .setParent(parent_id)
+                .setQuery(filename);
+
+            var picker = builder
+                .addView(search_view)
+                .setOAuthToken(gapi.auth.getToken()['access_token'])
+                .setAppId(gapi_utils.APP_ID)
+                .setCallback(callback)
+                .build();
+
+            picker.setVisible(true);
+        });
+    };
+
+    var picker_utils = {
+        pick_file: pick_file
+    };
+
+    return picker_utils;
+});


### PR DESCRIPTION
When particular file was not created with this app, or has not been opened in the FilePicker before with this app, the user cannot load that file.  This is a security measure that prevents our app accessing arbitrary user data (see drive.file scope in Google API documentation).  This commit prompts the user to select a file in the FilePicker, whenever we need access to a file.