### PR TITLE
Updates clobber detection and removes checkpointing

### DIFF
--- a/jupyterdrive/gdrive/drive-contents.js
+++ b/jupyterdrive/gdrive/drive-contents.js
@@ -11,44 +11,9 @@ define(function(require) {
     var drive_utils = require('./drive_utils');
     var notebook_model = require('./notebook_model');
 
-    var Contents = function(options) {
-        // Constructor
-        //
-        // A contentmanager handles passing file operations
-        // to the back-end.  This includes checkpointing
-        // with the normal file operations.
-        //
-        // Parameters:
-        //  options: dictionary
-        //      Dictionary of keyword arguments.
-        //          base_url: string
-        this.base_url = options.base_url;
-
-        /**
-         * Stores the revision id from the last save or load.  This is used
-         * when checking if a file has been modified by another user.
-         */
-        this.last_observed_revision = {};
-        gapi_utils.gapi_ready.then(drive_utils.set_user_info);
-    };
-
     /**
      * Utility functions
      */
-
-    /**
-     * This function should be called when a file is modified or opened.  It
-     * caches the revisionId of the head revision of that file.  This
-     * information is used for two purposes.  First, it is used to determine
-     * if another user has changed a file, in order to warn a user that they
-     * may be overwriting another user's work.  Second, it is used to
-     * checkpoint after saving.
-     *
-     * @param {resource} resource_prm a Google Drive file resource.
-     */
-    Contents.prototype.observe_file_resource = function(resource) {
-        this.last_observed_revision[resource['id']] = resource['headRevisionId'];
-    };
 
     /**
      * Converts a Google Drive files resource, (see
@@ -87,6 +52,136 @@ define(function(require) {
     };
 
     /**
+     * A utility class to detect cloberring of files by other users
+     */
+    var ClobberDetector = function() {
+        /**
+         * Stores the last few UUIDs that were attached to the last save
+         * for a given file.  This is used when checking if a file has been
+         *  modified by another user.
+         */
+        this.save_uuids = {};
+    };
+
+    /**
+     * @type {String}
+     * A UUID used to detect when other users overwrite saves done by
+     * this client.  If this property of the file changes, then
+     * the user is warned that another user is also saving to the file
+     * and that user's work will be overwritten.
+     */
+    ClobberDetector.SAVE_UUID_KEY = 'save_uuid';
+
+    /**
+     * @type {Number}
+     * The number of UUIDs per file to keep track of.
+     */
+    ClobberDetector.NUM_UUIDS_IN_CACHE = 100;
+
+    ClobberDetector.prototype.add_uuid_to_cache = function(resource, uuid) {
+        var file_id = resource['id'];
+        this.save_uuids[file_id] = this.save_uuids[file_id] || [];
+        var uuids = this.save_uuids[file_id];
+        uuids.push(uuid);
+        if (uuids.length > ClobberDetector.NUM_UUIDS_IN_CACHE) {
+            uuids.shift();
+        }
+        console.log(uuids);
+    }
+
+    /**
+     * Returns a UUID
+     * @return {string}
+     */
+    ClobberDetector.prototype.create_uuid = function() {
+        return Math.random().toString().substr(2);
+    }
+
+    /**
+     * Returns file metadata that sets a custom property to record
+     * the provided uuid as the id of the last save
+     * @return {Object}
+     */
+    ClobberDetector.prototype.create_metadata = function(uuid) {
+        return {
+            'properties' : [{
+                'visibility': 'PRIVATE',  // only visible to this app
+                'key': ClobberDetector.SAVE_UUID_KEY,
+                'value': uuid
+            }]
+        };
+    };
+
+    /**
+     * Should be called whenever a file loaded.  Since the file being
+     * loaded is the one that will populate this document, the SAVE_ID
+     * of this file will be assumed not to indicate cloberring.
+     * @param {Object} resource The Fiels resource of the file that was
+     *     loaded.
+     */
+    ClobberDetector.prototype.on_load_file = function(resource) {
+        // Go through all properties, searching for the relevant property,
+        // and record it if it exists.
+        var that = this;
+        if (!resource['properties']) { return; }
+        resource['properties'].forEach(function(property) {
+            if (property['visibility'] === 'PRIVATE'
+                && property['key']=== ClobberDetector.SAVE_UUID_KEY) {
+                that.add_uuid_to_cache(resource, property['value']);
+            }
+        });
+    };
+
+    /**
+     * Should be called whenever a new version of the file is uploaded
+     * to drive.  Returns metadata that should be uploaded along with
+     * the file.  This metadata identifies the last save.
+     * @param {Object} resource The Files resource of the file being saved
+     * @return {Object} metdata to upload with the file.
+     */
+    ClobberDetector.prototype.on_upload_new_version = function(resource) {
+        var uuid = this.create_uuid();
+        this.add_uuid_to_cache(resource, uuid);
+        return this.create_metadata(uuid);
+    };
+
+    /**
+     * Detects whether a file has been clobbered by another user
+     * @return {Bool} True if clobbering is detected.
+     */
+    ClobberDetector.prototype.has_clobber_occurred = function(resource) {
+        console.log(this.save_uuids);
+        var uuids = this.save_uuids[resource['id']];
+        // In the unlikely event that there are no uuid's for this file
+        // assume no clobbering has occurred.
+        if (!uuids) { return false; }
+        return !resource['properties'].some(function(property) {
+            return property['visibility'] === 'PRIVATE'
+                && property['key'] === ClobberDetector.SAVE_UUID_KEY
+                && uuids.indexOf(property['value']) != -1;
+        });
+    };
+
+    var Contents = function(options) {
+        // Constructor
+        //
+        // A contentmanager handles passing file operations
+        // to the back-end.  This includes checkpointing
+        // with the normal file operations.
+        //
+        // Parameters:
+        //  options: dictionary
+        //      Dictionary of keyword arguments.
+        //          base_url: string
+        this.base_url = options.base_url;
+
+        this.clobber_detector = new ClobberDetector();
+
+        gapi_utils.gapi_ready.then(drive_utils.set_user_info);
+    };
+
+
+    /**
      * Notebook Functions
      */
 
@@ -106,7 +201,6 @@ define(function(require) {
         var metadata_prm = gapi_utils.gapi_ready.then(
             $.proxy(drive_utils.get_resource_for_path, this, path, drive_utils.FileType.FILE));
         var contents_prm = metadata_prm.then(function(resource) {
-            that.observe_file_resource(resource);
             return gapi_utils
                 .download(resource['downloadUrl'])
                 .catch(function(data){
@@ -126,6 +220,9 @@ define(function(require) {
         return Promise.all([metadata_prm, contents_prm]).then(function(values) {
             var metadata = values[0];
             var contents = values[1];
+            // Let the clobber detector see the metadata for the file we just
+            // loaded.
+            that.clobber_detector.on_load_file(metadata);
             var model = files_resource_to_contents_model(path, metadata);
             model['content'] = notebook_model.notebook_from_file_contents(contents);
             model['writable'] = metadata['editable'];
@@ -153,7 +250,12 @@ define(function(require) {
                 'parents' : [{'id' : folder_id}],
                 'title' : filename,
                 'description': 'IP[y] file',
-                'mimeType': drive_utils.NOTEBOOK_MIMETYPE
+                'mimeType': drive_utils.NOTEBOOK_MIMETYPE,
+                'properties': [{
+                    'visibility': 'PRIVATE',
+                    'key': ClobberDetector.SAVE_UUID_KEY,
+                    'value': 'INITIAL_UPLOAD'
+                }]
             }
             return drive_utils.upload_to_drive(contents, metadata);
         })
@@ -213,7 +315,6 @@ define(function(require) {
             return gapi_utils.execute(request);
         })
         .then(function(resource) {
-            that.observe_file_resource(resource);
             return files_resource_to_contents_model(path, resource);
         });
     };
@@ -225,10 +326,13 @@ define(function(require) {
             var contents =
         notebook_model.file_contents_from_notebook(model.content);
             var save = function() {
-                return drive_utils.upload_to_drive(contents, {}, resource['id']);
+                // Get metadata to upload with this file, so that the clobber
+                // detector can recognize the version just saved.
+                var metadata = that.clobber_detector.on_upload_new_version(resource);
+                return drive_utils.upload_to_drive(contents, metadata, resource['id']);
             };
-            if (resource['headRevisionId'] !=
-                that.last_observed_revision[resource['id']]) {
+
+            if (that.clobber_detector.has_clobber_occurred(resource)) {
                 // The revision id of the files resource does not match the
                 // cached revision id for this file.  This implies that the
                 // file has been modified by another user/tab during this
@@ -252,7 +356,6 @@ define(function(require) {
             return save();
         })
         .then(function(resource) {
-            that.observe_file_resource(resource);
             return files_resource_to_contents_model(path, resource);
         });
     };
@@ -264,29 +367,7 @@ define(function(require) {
     // NOTE: it would be better modify the API to combine create_checkpoint with
     // save
     Contents.prototype.create_checkpoint = function(path, options) {
-        var that = this;
-        return gapi_utils.gapi_ready
-        .then($.proxy(drive_utils.get_id_for_path, this, path, drive_utils.FileType.FILE))
-        .then(function(file_id) {
-            var revision_id = that.last_observed_revision[file_id];
-            if (!revision_id) {
-                return Promise.reject(new Error('File must be saved before checkpointing'));
-            }
-            var body = {'pinned': true};
-            var request = gapi.client.drive.revisions.patch({
-                'fileId': file_id,
-                'revisionId': revision_id,
-                'resource': body
-            });
-            return gapi_utils.execute(request);
-        })
-        .then(function(item) {
-            return {
-                last_modified: item['modifiedDate'],
-                id: item['id'],
-                drive_resource: item
-            };
-        });
+        return Promise.reject(new Error('create_checkpoint not implemented'));
     };
 
     Contents.prototype.restore_checkpoint = function(path, checkpoint_id, options) {


### PR DESCRIPTION
The new behavior of Google Drive requires a new system for detecting clobbering by other users, and also breaks checkpointing.  This commit adds a new method for detecting clobbering, by writing a custom property to the files metadata with each save.  If an unexpected value of this property is observed, this indicates that another user is modifying this file.  This method is not failsafe, but shoud be reliable if users dont save to frequently.  Checkpointing is removed because there is no way to reliably checkpoint when we don't know what the last saved revision is.