### PR TITLE
Use utils.url_path_join instead of ad hoc code

### DIFF
--- a/jupyterdrive/gdrive/drive-contents.js
+++ b/jupyterdrive/gdrive/drive-contents.js
@@ -457,7 +457,7 @@ define(function(require) {
         })
         .then(function(items) {
             var list = $.map(items, function(resource) {
-                var fullpath = path + '/' + resource['title'];
+                var fullpath = utils.url_path_join(path, resource['title']);
                 return files_resource_to_contents_model(fullpath, resource)
             });
             return {content: list};


### PR DESCRIPTION
Ad hoc code to join paths was causing bugs when path was empty.  The code was changed to call utils.url_path_join.