### PR TITLE
Generalize the Mixed content manager

### DIFF
--- a/jupyterdrive/gdrive/mixed-contents.js
+++ b/jupyterdrive/gdrive/mixed-contents.js
@@ -108,48 +108,78 @@ define(function(require) {
      * Takes a file model, and convert its path to the virtual filesystem.
      * from Google Drive format
      * @param {String} root The root of the virtual mount point.
-     * @param {Object} model The file model (this is modified by the function).
+     * @param {Object} file The file model (this is modified by the function).
      * @return {Object} the converted file model
      */
-    var to_virtual_model = function(root, model) {
-        model['path'] = to_virtual_path(root, model['path']);
-        return model;
+    var to_virtual_file = function(root, file) {
+        file['path'] = to_virtual_path(root, file['path']);
+        return file;
     };
 
     /**
      * Takes a file list, and convert its path to the virtual filesystem.
      * from Google Drive format
      * @param {String} root The root of the virtual mount point.
-     * @param {Object} model The file list (this is modified by the function).
+     * @param {Object} list The file list (this is modified by the function).
      * @return {Object} The converted file list
      */
     var to_virtual_list = function(root, list) {
-        list['content'].forEach($.proxy(to_virtual_model, this, root));
+        list['content'].forEach($.proxy(to_virtual_file, this, root));
         return list;
+    };
+
+    /** Enum for object types */
+    var ArgType = {
+        PATH : 1,
+        FILE : 2,
+        LIST : 3,
+        OTHER : 4
+    };
+
+    var to_virtual = function(root, type, object) {
+        if (type === ArgType.PATH) {
+            return to_virtual_path(root, object);
+        } else if (type === ArgType.FILE) {
+            return to_virtual_file(root, object);
+        } else if (type === ArgType.LIST) {
+            return to_virtual_list(root, object);
+        } else {
+            return object;
+        }
+    };
+
+    var from_virtual = function(root, type, object) {
+        if (type === ArgType.PATH) {
+            return from_virtual_path(root, object);
+        } else if (type === ArgType.FILE) {
+            throw "from_virtual_file not implemented";
+        } else if (type === ArgType.LIST) {
+            throw "from_virtual_list not implemented";
+        } else {
+            return object;
+        }
     };
 
     /**
      * Route a function to the appropriate content manager class
      * @param {string} method_name Name of the method being called
-     * @param {Array} path_args the indices of the arguments which are paths
+     * @param {Array} arg_types Types of the arguments to the function
+     * @param {Array} arg_types Type of the return value of the function
      * @param {Array} args the arguments to apply
-     * @param {Function} drive_continuation Function to apply to arguments when Google Drive is selected.
      */
-    Contents.prototype.route_function = function(method_name, path_args, args, drive_continuation) {
-        if (path_args.length == 0) {
-            // Unexpected error: if path_args is empty then there is no way to
-            // route this function, since there is no way to tell which
-            // Contents instance to use.
-            throw 'path_args was empty, so route_function cannot determine which Contents instance to use';
+    Contents.prototype.route_function = function(method_name, arg_types, return_type, args) {
+        if (arg_types.length == 0 || arg_types[0] != ArgType.PATH) {
+            // This should never happen since arg_types is hard coded below.
+            throw 'unexpected value of arg_types';
         }
-        var root = this.get_fs_root(args[path_args[0]]);
-        for (var i = 0; i < path_args.length; i++) {
-            var idx = path_args[i];
-            args[idx] = from_virtual_path(root, args[idx]);
+        var root = this.get_fs_root(args[0]);
+
+        for (var i = 0; i < args.length; i++) {
+            args[i] = from_virtual(root, arg_types[i], args[i]);
         }
         var contents = this.filesystem[root];
         return contents[method_name].apply(contents, args).then(
-            $.proxy(drive_continuation, this, root));
+            $.proxy(to_virtual, this, root, return_type));
     };
 
     /**
@@ -157,28 +187,46 @@ define(function(require) {
      */
 
     Contents.prototype.get = function (path, type, options) {
-        return this.route_function('get', [0], arguments, to_virtual_model);
+        return this.route_function(
+            'get',
+            [ArgType.PATH, ArgType.OTHER, ArgType.OTHER],
+            ArgType.FILE, arguments);
     };
 
     Contents.prototype.new_untitled = function(path, options) {
-        return this.route_function('new_untitled', [0], arguments, to_virtual_model);
+        return this.route_function(
+            'new_untitled',
+            [ArgType.PATH, ArgType.OTHER],
+            ArgType.FILE, arguments);
     };
 
     Contents.prototype.delete = function(path) {
-        return this.route_function('delete', [0], arguments, function(x) {return x;});
+        return this.route_function(
+            'delete',
+            [ArgType.PATH],
+            ArgType.FILE, arguments);
     };
 
     Contents.prototype.rename = function(path, new_path) {
-        return this.route_function('rename', [0, 1], arguments, to_virtual_model);
+        return this.route_function(
+            'rename',
+            [ArgType.PATH, ArgType.PATH],
+            ArgType.FILE, arguments);
     };
 
     Contents.prototype.save = function(path, model, options) {
-        return this.route_function('save', [0], arguments, to_virtual_model);
+        return this.route_function(
+            'save',
+            [ArgType.PATH, ArgType.OTHER, ArgType.OTHER],
+            ArgType.FILE, arguments);
     };
 
     Contents.prototype.list_contents = function(path, options) {
         var that = this;
-        return this.route_function('list_contents', [0], arguments, to_virtual_list)
+        return this.route_function(
+            'list_contents',
+            [ArgType.PATH, ArgType.OTHER],
+            ArgType.LIST, arguments)
         .then(function(response) {
             if (path === '') {
                 // If this is the root path, add the drive mountpoint directory.
@@ -189,7 +237,10 @@ define(function(require) {
     };
 
     Contents.prototype.copy = function(from_file, to_dir) {
-        return this.route_function('copy', [0, 1], arguments);
+        return this.route_function(
+            'copy',
+            [ArgType.PATH, ArgType.PATH],
+            ArgType.FILE, arguments);
     };
 
     /**
@@ -197,15 +248,24 @@ define(function(require) {
      */
 
     Contents.prototype.create_checkpoint = function(path, options) {
-        return this.route_function('create_checkpoint', [0], arguments);
+        return this.route_function(
+            'create_checkpoint',
+            [ArgType.PATH, ArgType.OTHER],
+            ArgType.OTHER, arguments);
     };
 
     Contents.prototype.restore_checkpoint = function(path, checkpoint_id, options) {
-        return this.route_function('restore_checkpoint', [0], arguments);
+        return this.route_function(
+            'restore_checkpoint',
+            [ArgType.PATH, ArgType.OTHER, ArgType.OTHER],
+            ArgType.OTHER, arguments);
     };
 
     Contents.prototype.list_checkpoints = function(path, options) {
-        return this.route_function('list_checkpoints', [0], arguments);
+        return this.route_function(
+            'list_checkpoints',
+            [ArgType.PATH, ArgType.OTHER],
+            ArgType.OTHER, arguments);
     };
 
     IPython.Contents = Contents;


### PR DESCRIPTION
This PR makes the client code more generalizable, and also generally cleans up the client side code.  Now the code explicitly recognizes 4 kinds of object that need to be converted: paths, file model objects, file list model objects, and objects that don't need any conversion.  These are enumerated by ```ArgType```.