### PR TITLE
Make JS mixed contents configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,78 @@ python -m jupyterdrive default --mixed
 The mixed content manager will show both contents from local hard drive and remote
 google drive as two directory in your dashboard.
 
+#### mixed content configuration.
+
+All the following files should be created automatically
+once you have used the content manager once. You should
+need to modify these file manually to have the contents maager working in most cases.
+
+To modify the configuration of the mixed contents manager you need to update the following files:
+
+`<profile_mixed>/ipython_notebook_config.json` which by default should heve the following structure :
+
+
+```json
+{
+  "nbformat": 1,
+  "NotebookApp": {
+    "contents_manager_class": "jupyterdrive.mixednbmanager.MixedContentsManager",
+    "tornado_settings": {
+      "contents_js_source": "nbextensions/gdrive/mixed-contents"
+    }
+  },
+  "MixedContentsManager":{
+    "filesystem_scheme": [
+        {
+          "root":"local",
+          "contents":"IPython.html.services.contents.filemanager.FileConensManager"
+        },
+        {
+          "root": "gdrive",
+          "contents": "jpyerdrive.clientsidenbmanager.ClientSideContentsManager"
+        }
+      ]
+  }
+
+}
+```
+
+The `root` field of `filesystem_scheme` represent the name that would be use as
+virtual mount points for the contents manager in the dashbord and should be
+consistent with the name given in `nbconfig/common.json` describe below.
+
+the `contents` field contains the fully qualified name of a Contents manager to
+mount on the mountpoint.
+
+The second config file that deals with configuring the frontend is
+`<profile_mixed>/nbconfig/common.json` and by default should be:
+
+```json
+{
+  "mixed_contents": {
+    "schema": [
+      {
+        "stripjs": false,
+        "contents": "services/contents",
+        "root": "local"
+      },
+      {
+        "stripjs": true,
+        "contents": "./drive-contents",
+        "root": "gdrive"
+      }
+    ]
+  }
+}
+```
+
+As stated previously the `root` value should match python side config file,
+`contents` represent the client-side content manager that need to be use.
+`stripjs` is a boolean value that indicate weather the name of the mount point
+should be stripped from the various path on the javascript side before passing
+it to the differents subcontent manager.
+
+
 
 ## Other options
 
@@ -94,7 +166,7 @@ view files/directories in the tree view.
 
 ## Advance configuration.
 
-The contens manager can access the `common` section of nbconfig, thus
+The contents manager can access the `common` section of nbconfig, thus
 you can set config values in `<profile_dir>/nbconfig/common.json`. The default
 value that are use are the following:
 

--- a/jupyterdrive/mixed_contents.json
+++ b/jupyterdrive/mixed_contents.json
@@ -1,7 +1,20 @@
 {
   "version" : 1,
   "NotebookApp":{
-    "tornado_settings": {"contents_js_source": "nbextensions/gdrive/mixed-contents"}, 
+    "tornado_settings": {"contents_js_source": "nbextensions/gdrive/mixed-contents"},
     "contents_manager_class": "jupyterdrive.mixednbmanager.MixedContentsManager"
+  },
+  "MixedContentsManager":{
+    "filesystem_scheme": [
+        {
+            "root":"local",
+            "contents":"IPython.html.services.contents.filemanager.FileContentsManager"
+        },
+        {
+            "root": "gdrive",
+            "contents": "jupyterdrive.clientsidenbmanager.ClientSideContentsManager"
+        }
+    ]
   }
+
 }

--- a/jupyterdrive/mixednbmanager.py
+++ b/jupyterdrive/mixednbmanager.py
@@ -55,7 +55,8 @@ class MixedContentsManager(ContentsManager):
     def path_dispatch2(method):
         def _wrapper_method(self, other, path, *args, **kwargs):
             path = path.strip('/')
-            (sentinel, *_path) = path.split('/')
+            _path = path.split('/')
+            sentinel = _path.pop(0)
             man = self.managers.get(sentinel, None)
             if man is not None:
                 meth = getattr(man, method.__name__)
@@ -68,7 +69,8 @@ class MixedContentsManager(ContentsManager):
     def path_dispatch_kwarg(method):
         def _wrapper_method(self, path=''):
             path = path.strip('/')
-            (sentinel, *_path) = path.split('/')
+            _path = path.split('/')
+            sentinel = _path.pop(0)
             man = self.managers.get(sentinel, None)
             if man is not None:
                 meth = getattr(man, method.__name__)
@@ -84,7 +86,7 @@ class MixedContentsManager(ContentsManager):
     @path_dispatch1
     def dir_exists(self, path):
         ## root exists
-        if path is '':
+        if len(path) == 0:
             return True
         if path in self.managers.keys():
             return True
@@ -92,20 +94,26 @@ class MixedContentsManager(ContentsManager):
 
     @path_dispatch1
     def is_hidden(self, path):
-        if (path is '') or path in self.managers.keys():
+        if (len(path) == 0) or path in self.managers.keys():
             return False;
         raise NotImplementedError('....'+path)
 
     @path_dispatch_kwarg
     def file_exists(self, path=''):
+        if len(path) == 0:
+            return False
         raise NotImplementedError('NotImplementedError')
 
     @path_dispatch1
     def exists(self, path):
+        if len(path) == 0:
+            return True
         raise NotImplementedError('NotImplementedError')
 
     @path_dispatch1
     def get(self, path, **kwargs):
+        if len(path) == 0:
+            return [ {'type':'directory'}]
         raise NotImplementedError('NotImplementedError')
 
     @path_dispatch2

--- a/jupyterdrive/mixednbmanager.py
+++ b/jupyterdrive/mixednbmanager.py
@@ -4,66 +4,137 @@
 # Distributed under the terms of the Modified BSD License.
 
 from IPython.html.services.contents.manager import ContentsManager
-from IPython.html.services.contents.filemanager import FileContentsManager
-from .clientsidenbmanager import ClientSideContentsManager
+from IPython.utils.traitlets import List
+from IPython.utils.importstring import import_item
 
 class MixedContentsManager(ContentsManager):
-    DRIVE_PATH_SENTINEL = 'gdrive'
+
+    filesystem_scheme = List([
+            {
+                'root':'local',
+                'contents':"IPython.html.services.contents.filemanager.FileContentsManager"
+            },
+            {
+                'root': 'gdrive',
+                'contents': 'jupyterdrive.clientsidenbmanager.ClientSideContentsManager'
+            }
+        ],
+    help="""
+    List of virtual mount point name and corresponding contents manager
+    """, config=True)
 
     def __init__(self, **kwargs):
-        self.file_contents_manager = FileContentsManager()
-        self.client_side_contents_manager = ClientSideContentsManager()
 
-    def is_drive_path(self, path):
-        components = path.split('/');
-        return components and components[0] == self.DRIVE_PATH_SENTINEL
+        super(MixedContentsManager, self).__init__(**kwargs)
+        self.managers = {}
+
+        ## check consistency of scheme.
+        if not len(set(map(lambda x:x['root'], self.filesystem_scheme))) == len(self.filesystem_scheme):
+            raise ValueError('Scheme should not mount two contents manager on the same mountpoint')
+
+        kwargs.update({'parent':self})
+        for scheme in self.filesystem_scheme:
+            manager_class = import_item(scheme['contents'])
+            self.managers[scheme['root']] = manager_class(**kwargs)
+
+
+    def path_dispatch1(method):
+        def _wrapper_method(self, path, *args, **kwargs):
+            path = path.strip('/')
+            _path = path.split('/')
+            sentinel = _path.pop(0)
+            man = self.managers.get(sentinel, None)
+            if man is not None:
+                meth = getattr(man, method.__name__)
+                sub = meth('/'.join(_path), *args, **kwargs)
+                return sub
+            else :
+                return method(self, path, *args, **kwargs)
+        return _wrapper_method
+
+    def path_dispatch2(method):
+        def _wrapper_method(self, other, path, *args, **kwargs):
+            path = path.strip('/')
+            (sentinel, *_path) = path.split('/')
+            man = self.managers.get(sentinel, None)
+            if man is not None:
+                meth = getattr(man, method.__name__)
+                sub = meth(other, '/'.join(_path), *args, **kwargs)
+                return sub
+            else :
+                return method(self, other, path, *args, **kwargs)
+        return _wrapper_method
+
+    def path_dispatch_kwarg(method):
+        def _wrapper_method(self, path=''):
+            path = path.strip('/')
+            (sentinel, *_path) = path.split('/')
+            man = self.managers.get(sentinel, None)
+            if man is not None:
+                meth = getattr(man, method.__name__)
+                sub = meth(path='/'.join(_path))
+                return sub
+            else :
+                return method(self, path=path)
+        return _wrapper_method
 
     # ContentsManager API part 1: methods that must be
     # implemented in subclasses.
 
+    @path_dispatch1
     def dir_exists(self, path):
-        if self.is_drive_path(path):
-            return self.client_side_contents_manager.dir_exists(path)
-        return self.file_contents_manager.dir_exists(path)
+        ## root exists
+        if path is '':
+            return True
+        if path in self.managers.keys():
+            return True
+        return False
 
+    @path_dispatch1
     def is_hidden(self, path):
-        if self.is_drive_path(path):
-            return self.client_side_contents_manager.is_hidden(path)
-        return self.file_contents_manager.is_hidden(path)
+        if (path is '') or path in self.managers.keys():
+            return False;
+        raise NotImplementedError('....'+path)
 
+    @path_dispatch_kwarg
     def file_exists(self, path=''):
-        if self.is_drive_path(path):
-            return self.client_side_contents_manager.file_exists(path)
-        return self.file_contents_manager.file_exists(path)
+        raise NotImplementedError('NotImplementedError')
 
+    @path_dispatch1
     def exists(self, path):
-        return self.file_contents_manager.exists(path)
+        raise NotImplementedError('NotImplementedError')
 
+    @path_dispatch1
     def get(self, path, **kwargs):
-        if self.is_drive_path(path):
-            return self.client_side_contents_manager.get(path, **kwargs)
-        return self.file_contents_manager.get(path, **kwargs)
+        raise NotImplementedError('NotImplementedError')
 
+    @path_dispatch2
     def save(self, model, path):
-        return self.file_contents_manager.save(model, path)
+        raise NotImplementedError('NotImplementedError')
 
+    @path_dispatch2
     def update(self, model, path):
-        return self.file_contents_manager.update(model, path)
+        raise NotImplementedError('NotImplementedError')
 
+    @path_dispatch1
     def delete(self, path):
-        return self.file_contents_manager.delete(path)
+        raise NotImplementedError('NotImplementedError')
 
+    @path_dispatch1
     def create_checkpoint(self, path):
-        return self.file_contents_manager.create_checkpoint(path)
+        raise NotImplementedError('NotImplementedError')
 
+    @path_dispatch1
     def list_checkpoints(self, path):
-        return self.file_contents_manager.list_checkpoints(path)
+        raise NotImplementedError('NotImplementedError')
 
+    @path_dispatch2
     def restore_checkpoint(self, checkpoint_id, path):
-        return self.file_contents_manager.restore_checkpoint(checkpoint_id, path)
+        raise NotImplementedError('NotImplementedError')
 
+    @path_dispatch2
     def delete_checkpoint(self, checkpoint_id, path):
-        return self.file_contents_manager.delete_checkpoint(checkpoint_id, path)
+        raise NotImplementedError('NotImplementedError')
 
     # ContentsManager API part 2: methods that have useable default
     # implementations, but can be overridden in subclasses.


### PR DESCRIPTION
Makes mixed contents configurable, and makes mount points ```gdrive``` and ```local``` instead of ```gdrive``` and ```/```.

Requires ```nbconfig/common.json``` contain something like

```
{
 "mixed_contents":
    { "schema" : [
        {
            "root": "local",
            "contents": "services/contents"
        },
        {
            "root": "gdrive",
            "contents": "./drive-contents"
        }
    ]
  }
}

```