### PR TITLE
Simplify detection of when a file can't be opened with drive.file scope

### DIFF
--- a/jupyterdrive/gdrive/drive-contents.js
+++ b/jupyterdrive/gdrive/drive-contents.js
@@ -222,7 +222,7 @@ define(function(require) {
             $.proxy(drive_utils.get_resource_for_path, this, path, drive_utils.FileType.FILE));
         var contents_prm = metadata_prm.then(function(resource) {
             that.observe_file_resource(resource);
-            return drive_utils.get_contents(resource, false, 0);
+            return drive_utils.get_contents(resource, false);
         });
 
         return Promise.all([metadata_prm, contents_prm]).then(function(values) {

--- a/jupyterdrive/gdrive/drive-contents.js
+++ b/jupyterdrive/gdrive/drive-contents.js
@@ -10,7 +10,6 @@ define(function(require) {
     var gapi_utils = require('./gapi_utils');
     var drive_utils = require('./drive_utils');
     var notebook_model = require('./notebook_model');
-    var picker_utils = require('./picker_utils');
 
     var Contents = function(options) {
         // Constructor
@@ -223,21 +222,8 @@ define(function(require) {
             $.proxy(drive_utils.get_resource_for_path, this, path, drive_utils.FileType.FILE));
         var contents_prm = metadata_prm.then(function(resource) {
             that.observe_file_resource(resource);
-            // If downloadUrl field is missing, this means that we do not have
-            // access to the file using drive.file scope.  Therefore we prompt
-            // the user to open a FilePicker window that allows them to indicate
-            // to Google Drive that they intend to open that file with this
-            // app.
-            if (resource['downloadUrl']) {
-                return gapi_utils.download(resource['downloadUrl']);
-            } else {
-                // TODO: implement exponential backoff as file is not
-                // available immediately after user selects in.  Up to 3
-                // seconds latency is typical.
-                return picker_utils.pick_file(resource.parents[0]['id'], resource['title'])
-                .then(function() { return gapi_utils.download(resource['downloadUrl']); });
-            }
-        })
+            return drive_utils.get_contents(resource, false, 0);
+        });
 
         return Promise.all([metadata_prm, contents_prm]).then(function(values) {
             var metadata = values[0];

--- a/jupyterdrive/gdrive/drive_utils.js
+++ b/jupyterdrive/gdrive/drive_utils.js
@@ -8,6 +8,7 @@ define(function(require) {
     var jquery =     require('jquery');
     var $ = jquery;
     var gapi_utils = require('./gapi_utils');
+    var picker_utils = require('./picker_utils');
 
     var FOLDER_MIME_TYPE = 'application/vnd.google-apps.folder';
 
@@ -244,6 +245,50 @@ define(function(require) {
         return gapi_utils.execute(request);
     };
 
+    var GET_CONTENTS_INITIAL_DELAY = 200;  // 200 ms
+    var GET_CONTENTS_MAX_TRIES = 5;
+    var GET_CONTENTS_EXPONENTIAL_BACKOFF_FACTOR = 2.0;
+
+    /**
+     * Attempt to get the contents of a file with the given id.  This may
+     * involve requesting the user to open the file in a FilePicker.
+     * @param {Object} resource The files resource of the file.
+     * @param {Boolean} already_picked Set to true if this file has already
+     *     been selected by the FilePicker
+     * @param {Number} num_tries The number of times this file has been tried so
+     *     far, since the user picked in the file picker.
+     * @return {Promise} A promise fullfilled by file contents.
+     */
+    var get_contents = function(resource, already_picked, num_tries) {
+        if (resource['downloadUrl']) {
+            return gapi_utils.download(resource['downloadUrl']);
+        } else if (already_picked) {
+            if (num_tries == GET_CONTENTS_MAX_TRIES) {
+              return Promise.reject(new Error('Max retries of file load reached'));
+            }
+            var request = gapi.client.drive.files.get({ 'fileId': resource['id'] });
+            var reply = gapi_utils.execute(request);
+            var delay = GET_CONTENTS_INITIAL_DELAY *
+                Math.pow(GET_CONTENTS_EXPONENTIAL_BACKOFF_FACTOR, num_tries);
+            var delayed_reply = new Promise(function(resolve, reject) {
+                window.setTimeout(function() {
+                    resolve(reply);
+                }, delay);
+            });
+            return delayed_reply.then(function(new_resource) {
+                return get_contents(new_resource, true, num_tries + 1);
+            });
+        } else {
+            // If downloadUrl field is missing, this means that we do not have
+            // access to the file using drive.file scope.  Therefore we prompt
+            // the user to open a FilePicker window that allows them to indicate
+            // to Google Drive that they intend to open that file with this
+            // app.
+	    return picker_utils.pick_file(resource.parents[0]['id'], resource['title'])
+                .then(function() { return get_contents(resource, true, 0); });
+        }
+    };
+
     /**
      * Fetch user avatar url and put it in the header
      * optionally take a selector into which to insert the img tag
@@ -277,7 +322,8 @@ define(function(require) {
         get_resource_for_relative_path : get_resource_for_relative_path,
         get_resource_for_path : get_resource_for_path,
         get_new_filename : get_new_filename,
-        upload_to_drive : upload_to_drive, 
+        upload_to_drive : upload_to_drive,
+        get_contents : get_contents,
         set_user_info: set_user_info
     }
 


### PR DESCRIPTION
Drive.file scope requires explicit user permission to open a particular file.  This is done with the FilePicker API.  This change simplifies how this is detected.