### PR TITLE
How to launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,14 @@ in `.py` files, though you can still use non conflicting options.
 
 # First launch
 
+Launch with:
+
+```bash
+ipython notebook --profile <profilename>
+```
+
+You might need to add `sudo`, if you get permission errors.
+
 On first launch, the application will ask you for the authorization to access
 your files on Google Drive.  It only asks for permission to create new files or
  access files it has created or that you manually open with this application.


### PR DESCRIPTION
Added explicitly how to launch it. For me, it wasn't obvious. 

As a side remark, why not use `drive` as a profile name instead of using `<profilename>` (the later can by cryptic for anyone new to IPython, and reducing confusion is always good).

As a more general remark, isn't it possible to reduce installation to a one-liner?