### PR TITLE
complexify detection of JUPYTER vs IPYTHON

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,10 @@
 language: python
 cache: pip
 python:
+    - 3.3
     - 3.4
     - 2.7
+    - nightly
 sudo: false
 before_install:
     - git clone --quiet --depth 1 https://github.com/minrk/travis-wheels travis-wheels

--- a/jupyterdrive/compat.py
+++ b/jupyterdrive/compat.py
@@ -1,11 +1,44 @@
-from __future__ import print_function, absolute_import 
+from __future__ import print_function, absolute_import
 
-try: 
+import sys
+
+
+# loaded as a content manager, we can check wether IPython/jupyter is in sys module,
+# then the answer is unambiguous/
+DEFINITIVELY_JUPYTER = 'jupyter_notebook' in sys.modules
+
+# we might want to check wether this is in an IPython context (ie there is
+# IPython is sys.modules, but then we need to check version)
+
+MAYBE_IPYTHON = 'IPython' in sys.modules
+
+if MAYBE_IPYTHON and not DEFINITIVELY_JUPYTER:
+    import IPython
+    # IPython 4.0+ context, so we definitively
+    # should have Jupyter installed
+    if IPython.version_info >= (4,0):
+        DEFINITIVELY_JUPYTER = True
+
+JUPYTER = False
+
+if DEFINITIVELY_JUPYTER:
+    JUPYTER = True
+else:
+    # none of above in sys.module,
+    # we might be at install time.
+    # guess for the best.
+    try:
+        # if jupyter is installed, assume jupyter
+        import  jupyter_notebook.nbextensions
+        JUPYTER = True
+    except ImportError:
+        pass
+
+
+if JUPYTER:
     import  jupyter_notebook.nbextensions as nbe
-    JUPYTER=True
-except ImportError:
+else:
     import IPython.html.nbextensions as nbe
-    JUPYTER=False
 
-#silence pyflakes
+# silence pyflakes
 nbe

--- a/jupyterdrive/compat.py
+++ b/jupyterdrive/compat.py
@@ -30,6 +30,8 @@ else:
     try:
         # if jupyter is installed, assume jupyter
         import  jupyter_notebook.nbextensions
+        # silence pyflakes
+        jupyter_notebook.nbextensions
         JUPYTER = True
     except ImportError:
         pass

--- a/jupyterdrive/tests/test_install.py
+++ b/jupyterdrive/tests/test_install.py
@@ -1,23 +1,23 @@
 from __future__ import print_function, absolute_import
 
 
-from jupyterdrive import deactivate,install, activate
+from jupyterdrive import deactivate, install
 
 
 
-def test_install():
+def test_a_install():
     install(verbose=True, mixed=True, user=True)
 
-def test_deactivate():
+def test_b_deactivate():
     deactivate()
 
-def test_deactivate_2():
+def test_c_deactivate_2():
     deactivate()
 
-def test_install_normal():
+def test_d_install_normal():
     install(verbose=True, mixed=False, user=True)
 
-def test_deactivate_2():
+def test_e_deactivate_3():
     deactivate()
 
 


### PR DESCRIPTION
getting wether we are on IPython 3.x or Jupyter_notebook 4.x is tricky as the 2 can be installed as the same time. `try-import` and `in sys.modules` alone are not sufficient.