### PR TITLE
Add instructions on re-building JavaScript from TypeScript

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,3 +195,19 @@ values that are used are the following:
 
 The `APP_ID` section is not yet configurable, but should be configurable in the
 same way at some point in the future.
+
+# Developing
+
+The client-side code for jupyter-drive is written in TypeScript. The TypeScript
+transpiler can be installed using ``npm``:
+
+```console
+npm install
+```
+
+The JavaScript may then be re-compiled using ``npm run``:
+
+```console
+npm run gulp js
+```
+

--- a/package.json
+++ b/package.json
@@ -30,5 +30,8 @@
     "gulp-typescript": "^2.7.8",
     "tsd": "^0.6.3",
     "typescript": "^1.4.1"
+  },
+  "scripts": {
+    "gulp": "gulp"
   }
 }


### PR DESCRIPTION
I'm not a big JavaScript guy but I think I worked out how to re-build the JavaScript. This PR adds a ``gulp`` "script" to the npm config to allow the running of gulp directly without the usual tedious mucking about in ``node_modules/.bin``. It also adds a note to the README about building JavaScript.